### PR TITLE
"Fix" synthoid camera

### DIFF
--- a/Sentinel/NodeFactory.swift
+++ b/Sentinel/NodeFactory.swift
@@ -192,23 +192,20 @@ class NodeFactory: NSObject {
 
     func createSynthoidNode(height: Int, viewingAngle: Float) -> SynthoidNode {
         let clone = synthoid.clone()
-        clone.position = nodePositioning.calculateObjectPosition()
-        clone.position.y += Float(height) * 0.5 * nodePositioning.floorSize
+        clone.position = nodePositioning.calculateObjectPosition(height: height)
         clone.viewingAngle = viewingAngle
         return clone
     }
 
     func createTreeNode(height: Int) -> TreeNode {
         let clone = tree.clone()
-        clone.position = nodePositioning.calculateObjectPosition()
-        clone.position.y += Float(height) * 0.5 * nodePositioning.floorSize
+        clone.position = nodePositioning.calculateObjectPosition(height: height)
         return clone
     }
 
     func createRockNode(height: Int) -> RockNode {
         let clone = rock.clone()
-        clone.position = nodePositioning.calculateObjectPosition()
-        clone.position.y += Float(height) * 0.5 * nodePositioning.floorSize
+        clone.position = nodePositioning.calculateObjectPosition(height: height)
         let rotation = radiansInCircle * Float(drand48())
         clone.rotation = SCNVector4Make(0.0, 1.0, 0.0, rotation)
         return clone

--- a/Sentinel/NodePositioning.swift
+++ b/Sentinel/NodePositioning.swift
@@ -20,9 +20,10 @@ class NodePositioning: NSObject {
                               (Float(z) - (gridDepth / 2.0)) * floorSize)
     }
 
-    func calculateObjectPosition() -> SCNVector3 {
+    func calculateObjectPosition(height: Int = 0) -> SCNVector3 {
+        let heightOffset = Float(height) * 0.5 * floorSize
         return SCNVector3Make(0.0,
-                              0.5 * floorSize,
+                              (0.5 * floorSize) + heightOffset,
                               0.0)
     }
 }

--- a/Sentinel/SynthoidNode.swift
+++ b/Sentinel/SynthoidNode.swift
@@ -3,7 +3,9 @@ import SceneKit
 class SynthoidNode: SCNNode, PlaceableNode, ViewingNode, DetectableNode {
     var viewingAngle: Float = 0.0 {
         didSet {
+            let oldPosition = position
             transform = SCNMatrix4MakeRotation(viewingAngle, 0, 1, 0)
+            position = oldPosition
         }
     }
 
@@ -28,13 +30,14 @@ class SynthoidNode: SCNNode, PlaceableNode, ViewingNode, DetectableNode {
         let camera = SCNCamera()
         camera.automaticallyAdjustsZRange = true
         let cameraNode = SCNNode()
+        cameraNode.position.y += floorSize / 4.0
         cameraNode.name = cameraNodeName
         cameraNode.camera = camera
         addChildNode(cameraNode)
 
         name = synthoidNodeName
         categoryBitMask = interactiveNodeType.synthoid.rawValue
-        pivot = SCNMatrix4MakeTranslation(0.0, -1.0 * floorSize, 0.0)
+        pivot = SCNMatrix4MakeTranslation(0.0, -0.5 * floorSize, 0.0)
     }
 
     var floorNode: FloorNode? {
@@ -51,6 +54,8 @@ class SynthoidNode: SCNNode, PlaceableNode, ViewingNode, DetectableNode {
 
     func apply(rotationDelta radians: Float) {
         let newRadians = viewingAngle + radians
+        let oldPosition = position
         transform = SCNMatrix4MakeRotation(newRadians, 0, 1, 0)
+        position = oldPosition
     }
 }


### PR DESCRIPTION
Not 100% sure why, but I need to reset the `position` every time I change the `transform` property. This odd logic was lost when I moved to the new synthoid camera system.

Needs further investigation...